### PR TITLE
feat(#14): 네이버 프로필 사진 추가, 네이버 로그인 정보 수정

### DIFF
--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/controller/AuthController.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/controller/AuthController.java
@@ -1,12 +1,16 @@
 package com.capstone.bwlovers.auth.controller;
 
+import com.capstone.bwlovers.auth.domain.User;
 import com.capstone.bwlovers.auth.dto.request.NaverLoginRequest;
 import com.capstone.bwlovers.auth.dto.request.RefreshRequest;
+import com.capstone.bwlovers.auth.dto.request.UpdateNaverRequest;
 import com.capstone.bwlovers.auth.dto.response.TokenResponse;
+import com.capstone.bwlovers.auth.dto.response.UpdateNaverResponse;
 import com.capstone.bwlovers.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -34,4 +38,13 @@ public class AuthController {
         return authService.refreshTokens(request.getRefreshToken());
     }
 
+    /*
+    네이버 로그인 정보 수정 (닉네임, 프로필 사진만)
+     */
+    @PatchMapping("/naver")
+    public ResponseEntity<UpdateNaverResponse> updateNaver(@RequestBody UpdateNaverRequest request,
+                                                           @AuthenticationPrincipal User user) {
+        UpdateNaverResponse response = authService.updateNaver(user, request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/controller/AuthController.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.capstone.bwlovers.auth.controller;
 
-import com.capstone.bwlovers.auth.domain.User;
 import com.capstone.bwlovers.auth.dto.request.NaverLoginRequest;
 import com.capstone.bwlovers.auth.dto.request.RefreshRequest;
 import com.capstone.bwlovers.auth.dto.request.UpdateNaverRequest;
@@ -11,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -42,9 +42,10 @@ public class AuthController {
     네이버 로그인 정보 수정 (닉네임, 프로필 사진만)
      */
     @PatchMapping("/naver")
-    public ResponseEntity<UpdateNaverResponse> updateNaver(@RequestBody UpdateNaverRequest request,
-                                                           @AuthenticationPrincipal User user) {
-        UpdateNaverResponse response = authService.updateNaver(user, request);
+    public ResponseEntity<UpdateNaverResponse> updateNaver(@AuthenticationPrincipal OAuth2User principal,
+                                                           @RequestBody UpdateNaverRequest request) {
+        Long userId = principal.getAttribute("userId");
+        UpdateNaverResponse response = authService.updateNaver(userId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/domain/User.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/domain/User.java
@@ -1,6 +1,7 @@
 package com.capstone.bwlovers.auth.domain;
 
 import com.capstone.bwlovers.health.domain.HealthStatus;
+import com.capstone.bwlovers.pregnancy.domain.PregnancyInfo;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -38,8 +39,11 @@ public class User {
     @Column(length = 20)
     private String phone;
 
-//    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-//    private PregnancyInfo pregnancyInfo;
+    @Column(name = "profile_image_url", length = 500)
+    private String profileImageUrl;
+
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private PregnancyInfo pregnancyInfo;
 
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
     private HealthStatus healthStatus;

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/domain/User.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/domain/User.java
@@ -55,4 +55,9 @@ public class User {
         }
     }
 
+    public void update(String username, String profileImageUrl) {
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+    }
+
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/dto/request/UpdateNaverRequest.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/dto/request/UpdateNaverRequest.java
@@ -1,0 +1,11 @@
+package com.capstone.bwlovers.auth.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateNaverRequest {
+    private String username;
+    private String profileImageUrl;
+}

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/dto/response/NaverUserInfoResponse.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/dto/response/NaverUserInfoResponse.java
@@ -23,5 +23,7 @@ public class NaverUserInfoResponse {
 
         @JsonProperty("mobile")
         private String mobile;
+
+        private String profileImageUrl;
     }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/dto/response/UpdateNaverResponse.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/dto/response/UpdateNaverResponse.java
@@ -1,0 +1,13 @@
+package com.capstone.bwlovers.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class UpdateNaverResponse {
+    private String username;
+    private String profileImageUrl;
+}

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/service/AuthService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/service/AuthService.java
@@ -134,22 +134,18 @@ public class AuthService {
     네이버 정보 수정
      */
     @Transactional
-    public UpdateNaverResponse updateNaver(User principalUser, UpdateNaverRequest req) {
-        if (principalUser == null) throw new CustomException(ExceptionCode.AUTH_TOKEN_INVALID);
+    public UpdateNaverResponse updateNaver(Long userId, UpdateNaverRequest request) {
 
-        // 영속 엔티티로 다시 로딩함 (provider/providerId 또는 userId로)
-        User user = userRepository.findById(principalUser.getUserId())
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
 
-        String newUsername = (req.getUsername() == null || req.getUsername().isBlank())
-                ? user.getUsername()
-                : req.getUsername().trim();
+        if (request.getUsername() != null && !request.getUsername().isBlank()) {
+            user.update(request.getUsername(), user.getProfileImageUrl());
+        }
 
-        String newProfile = (req.getProfileImageUrl() == null || req.getProfileImageUrl().isBlank())
-                ? user.getProfileImageUrl()
-                : req.getProfileImageUrl().trim();
-
-        user.update(newUsername, newProfile);
+        if (request.getProfileImageUrl() != null && !request.getProfileImageUrl().isBlank()) {
+            user.update(user.getUsername(), request.getProfileImageUrl());
+        }
 
         return new UpdateNaverResponse(user.getUsername(), user.getProfileImageUrl());
     }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/service/AuthService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/service/AuthService.java
@@ -63,6 +63,7 @@ public class AuthService {
         String email = userInfoRes.getResponse().getEmail();
         String name = userInfoRes.getResponse().getName();
         String mobile = userInfoRes.getResponse().getMobile();
+        String profileImageUrl = userInfoRes.getResponse().getProfileImageUrl();
 
         // DB upsert
         User user = userRepository.findByProviderAndProviderId(OAuthProvider.NAVER, providerId)
@@ -73,6 +74,7 @@ public class AuthService {
                                 .email(email == null ? "unknown@naver.com" : email) // email이 null일 수 있으면 방어
                                 .username(name)
                                 .phone(mobile)
+                                .profileImageUrl(profileImageUrl != null ? profileImageUrl : "/images/default-profile.png")
                                 .build()
                 ));
 

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/service/CustomOAuth2UserService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/service/CustomOAuth2UserService.java
@@ -62,8 +62,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         return new DefaultOAuth2User(
                 List.of(() -> "ROLE_USER"),
-                Map.of("subject", subject),
-                "subject"
+                Map.of("userId", user.getUserId()),
+                "userId"
         );
     }
 

--- a/bwlovers/src/main/java/com/capstone/bwlovers/health/controller/HealthStatusController.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/health/controller/HealthStatusController.java
@@ -1,6 +1,5 @@
 package com.capstone.bwlovers.health.controller;
 
-import com.capstone.bwlovers.auth.domain.User;
 import com.capstone.bwlovers.health.dto.request.HealthStatusRequest;
 import com.capstone.bwlovers.health.dto.response.HealthStatusResponse;
 import com.capstone.bwlovers.health.service.HealthStatusService;
@@ -8,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,30 +18,31 @@ public class HealthStatusController {
     private final HealthStatusService healthStatusService;
 
     /*
-    POST /me/health-status : 산모 건강 상태 등록
+     POST /users/me/health-status : 산모 건강 상태 등록
      */
     @PostMapping
-    public ResponseEntity<HealthStatusResponse> createHealthStatue(@Valid @RequestBody HealthStatusRequest request,
-                                                                   @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(healthStatusService.createHealthStatus(user.getUserId(), request));
+    public ResponseEntity<HealthStatusResponse> createHealthStatus(@Valid @RequestBody HealthStatusRequest request,
+                                                                   @AuthenticationPrincipal OAuth2User principal) {
+        Long userId = principal.getAttribute("userId");
+        return ResponseEntity.ok(healthStatusService.createHealthStatus(userId, request));
     }
 
     /*
-    GET /me/health-status : 산모 건강 상태 조회
+     GET /users/me/health-status : 산모 건강 상태 조회
      */
     @GetMapping
-    public ResponseEntity<HealthStatusResponse> getHealthStatus(@AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(healthStatusService.getHealthStatus(user.getUserId()));
+    public ResponseEntity<HealthStatusResponse> getHealthStatus(@AuthenticationPrincipal OAuth2User principal) {
+        Long userId = principal.getAttribute("userId");
+        return ResponseEntity.ok(healthStatusService.getHealthStatus(userId));
     }
 
     /*
-    PATCH /me/health-status : 산모 건강 상태 수정
+     PATCH /users/me/health-status : 산모 건강 상태 수정
      */
-    @PutMapping
+    @PatchMapping
     public ResponseEntity<HealthStatusResponse> updateHealthStatus(@Valid @RequestBody HealthStatusRequest request,
-                                                                   @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(healthStatusService.updateHealthStatus(user.getUserId(), request));
+                                                                   @AuthenticationPrincipal OAuth2User principal) {
+        Long userId = principal.getAttribute("userId");
+        return ResponseEntity.ok(healthStatusService.updateHealthStatus(userId, request));
     }
 }
-
-

--- a/bwlovers/src/main/java/com/capstone/bwlovers/pregnancy/controller/PregnancyInfoController.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/pregnancy/controller/PregnancyInfoController.java
@@ -1,44 +1,47 @@
 package com.capstone.bwlovers.pregnancy.controller;
 
-import com.capstone.bwlovers.auth.domain.User;
 import com.capstone.bwlovers.pregnancy.dto.request.PregnancyInfoRequest;
 import com.capstone.bwlovers.pregnancy.dto.response.PregnancyInfoResponse;
 import com.capstone.bwlovers.pregnancy.service.PregnancyInfoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("users/me/pregnancy-info")
+@RequestMapping("/users/me/pregnancy-info")
 public class PregnancyInfoController {
 
     private final PregnancyInfoService pregnancyInfoService;
 
     /*
-    POST /me/pregnancy-info : 산모 기본 정보 등록
+     POST /users/me/pregnancy-info : 산모 기본 정보 등록
      */
     @PostMapping
     public ResponseEntity<PregnancyInfoResponse> createPregnancyInfo(@RequestBody PregnancyInfoRequest request,
-                                                                     @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(pregnancyInfoService.createPregnancyInfo(user.getUserId(), request));
+                                                                     @AuthenticationPrincipal OAuth2User principal) {
+        Long userId = principal.getAttribute("userId");
+        return ResponseEntity.ok(pregnancyInfoService.createPregnancyInfo(userId, request));
     }
 
     /*
-    GET /me/pregnancy-info : 산모 기본 정보 조회
+     GET /users/me/pregnancy-info : 산모 기본 정보 조회
      */
     @GetMapping
-    public ResponseEntity<PregnancyInfoResponse> getPregnancyInfo(@AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(pregnancyInfoService.getPregnancyInfo(user.getUserId()));
+    public ResponseEntity<PregnancyInfoResponse> getPregnancyInfo(@AuthenticationPrincipal OAuth2User principal) {
+        Long userId = principal.getAttribute("userId");
+        return ResponseEntity.ok(pregnancyInfoService.getPregnancyInfo(userId));
     }
 
     /*
-    PATCH /me/pregnancy-info : 산모 정보 정보 수정
+     PATCH /users/me/pregnancy-info : 산모 기본 정보 수정
      */
     @PatchMapping
     public ResponseEntity<PregnancyInfoResponse> updatePregnancyInfo(@RequestBody PregnancyInfoRequest request,
-                                                                     @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(pregnancyInfoService.updatePregnancyInfo(user.getUserId(), request));
+                                                                     @AuthenticationPrincipal OAuth2User principal) {
+        Long userId = principal.getAttribute("userId");
+        return ResponseEntity.ok(pregnancyInfoService.updatePregnancyInfo(userId, request));
     }
 }


### PR DESCRIPTION
## 연관 이슈

close #14 

<br/>

## 설명

- 네이버 로그인 정보에 프로필 사진을 추가합니다.
- 네이버 로그인 정보(닉네임, 프로필 사진) 수정 가능하도록 합니다.

<br/>

## 📌 구현 기능

- [x] 네이버 로그인 정보에 프로필 사진 추가
- [x] 닉네임, 프로필 사진 수정 기능
- [x] 인증 principal을 User → OAuth2User(userId)로 통일

## 📷 테스트 결과
<img width="1578" height="844" alt="image" src="https://github.com/user-attachments/assets/a8b5b250-f786-4c88-82a8-48581f732803" />

<br/>

## ⚠️ 어려웠던 점과 해결 과정

SecurityContext에 저장된 principal은 인증 정보용 객체일 뿐이어서, 해당 객체를 직접 수정해도 JPA Dirty Checking이 동작하지 않아 DB에 변경 사항이 반영되지 않는 문제가 발생했습니다.
-> 따라서 principal의 역할을 사용자 식별(userId)로 한정하고, 비즈니스 로직에서는 userId를 기준으로 Service 계층에서 User 엔티티를 다시 조회하도록 구조를 변경했습니다.

주의!!!! OAuth2User는 OAuth2 로그인 플로우(세션 기반)로 들어올 때만 들어옴. JWT 요청에서는 OAuth2User가 아님!!!! 다시 수정함..
