### PR TITLE
feat(#27): 회원 탈퇴 기능 구현 (네이버 연동 해제 포함)

### DIFF
--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/controller/AuthController.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/controller/AuthController.java
@@ -1,14 +1,18 @@
 package com.capstone.bwlovers.auth.controller;
 
+import com.capstone.bwlovers.auth.domain.User;
 import com.capstone.bwlovers.auth.dto.request.NaverLoginRequest;
 import com.capstone.bwlovers.auth.dto.request.RefreshRequest;
 import com.capstone.bwlovers.auth.dto.request.UpdateNaverRequest;
 import com.capstone.bwlovers.auth.dto.response.TokenResponse;
 import com.capstone.bwlovers.auth.dto.response.UpdateNaverResponse;
 import com.capstone.bwlovers.auth.service.AuthService;
+import com.capstone.bwlovers.global.exception.CustomException;
+import com.capstone.bwlovers.global.exception.ExceptionCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
@@ -48,4 +52,14 @@ public class AuthController {
         UpdateNaverResponse response = authService.updateNaver(userId, request);
         return ResponseEntity.ok(response);
     }
+
+    /*
+    회원 탈퇴
+     */
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(Authentication authentication) {
+        authService.withdraw(authentication);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/domain/User.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/domain/User.java
@@ -45,10 +45,10 @@ public class User {
     @Column(name = "naver_access_token", length = 500) // 네이버 연동 해제용
     private String naverAccessToken;
 
-    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private PregnancyInfo pregnancyInfo;
 
-    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private HealthStatus healthStatus;
 
     public void setHealthStatus(HealthStatus healthStatus) {
@@ -66,5 +66,17 @@ public class User {
         this.username = username;
         this.profileImageUrl = profileImageUrl;
     }
+
+    public void clearRelations() {
+        if (this.pregnancyInfo != null) {
+            this.pregnancyInfo.setUser(null);
+            this.pregnancyInfo = null;
+        }
+        if (this.healthStatus != null) {
+            this.healthStatus.setUser(null);
+            this.healthStatus = null;
+        }
+    }
+
 
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/domain/User.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/domain/User.java
@@ -42,6 +42,9 @@ public class User {
     @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
+    @Column(name = "naver_access_token", length = 500) // 네이버 연동 해제용
+    private String naverAccessToken;
+
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private PregnancyInfo pregnancyInfo;
 
@@ -53,6 +56,10 @@ public class User {
         if (healthStatus != null && healthStatus.getUser() != this) {
             healthStatus.setUser(this);
         }
+    }
+
+    public void updateNaverToken(String naverAccessToken) {
+        this.naverAccessToken = naverAccessToken;
     }
 
     public void update(String username, String profileImageUrl) {

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/service/OAuthClient.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/service/OAuthClient.java
@@ -91,4 +91,38 @@ public class OAuthClient {
             throw new CustomException(ExceptionCode.INTERNAL_SERVER_ERROR);
         }
     }
+
+    /**
+     * 네이버 연동 해제 (Unlink)
+     */
+    public void deleteNaverLink(String naverAccessToken, String clientId, String clientSecret) {
+        if (naverAccessToken == null || naverAccessToken.isBlank()) {
+            throw new CustomException(ExceptionCode.AUTH_TOKEN_EMPTY);
+        }
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "delete");
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("access_token", naverAccessToken);
+        body.add("service_provider", "NAVER");
+
+        try {
+            String response = restClient.post()
+                    .uri("https://nid.naver.com/oauth2.0/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(String.class);
+
+            log.info("[NAVER REVOKE RESPONSE] {}", response);
+
+        } catch (RestClientResponseException e) {
+            log.warn("[NAVER REVOKE FAIL] status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new CustomException(ExceptionCode.AUTH_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error("[NAVER REVOKE ERROR]", e);
+            throw new CustomException(ExceptionCode.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/global/config/SecurityConfig.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/global/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
                                 "/login/**",
                                 "/ai/callback/**"
                         ).permitAll()
+                        .requestMatchers("/auth/withdraw").authenticated()
                         .anyRequest().authenticated()
                 )
 

--- a/bwlovers/src/main/java/com/capstone/bwlovers/health/domain/HealthStatus.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/health/domain/HealthStatus.java
@@ -5,7 +5,6 @@ import com.capstone.bwlovers.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/bwlovers/src/main/java/com/capstone/bwlovers/pregnancy/domain/PregnancyInfo.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/pregnancy/domain/PregnancyInfo.java
@@ -22,6 +22,7 @@ public class PregnancyInfo {
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
+    @Setter
     private User user;
 
     @Column(name = "birth_date", nullable = false)


### PR DESCRIPTION
## 연관 이슈

close #27 

<br/>

## 설명

JWT 인증 기반 회원 탈퇴 기능을 구현했습니다.  
탈퇴 시 네이버 OAuth 연동 해제(unlink)를 수행한 뒤, 사용자 및 연관 엔티티를 삭제하도록 구성했습니다.

<br/>

## 📌 구현 기능

- [x] JWT 인증 기반 회원 탈퇴 api
- [x] 네이버 OAuth 연동 해제 로직 추가
- [x] provider + providerId 기반 사용자 삭제 처리

## 📷 테스트 결과
<img width="1460" height="552" alt="image" src="https://github.com/user-attachments/assets/b51fd68f-ac75-4e62-8b0d-04a39f94f38d" />

<br/>

## ⚠️ 어려웠던 점과 해결 과정
- `/auth/** permitAll` 설정으로 인해 인증 객체가 null 상태로 컨트롤러 진입  
  -> `/auth/withdraw`를 authenticated 경로로 분리하고 서비스에서 인증 검증 수행

<br/>
  
## ⚠️ 참고 사항 및 주의할 점
- 현재 JWT secret 변경 시 기존 토큰은 모두 무효화됩니다.