### PR TITLE
feat(#35): 네이버 로그인 정보 조회

### DIFF
--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/controller/AuthController.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.capstone.bwlovers.auth.dto.request.RefreshRequest;
 import com.capstone.bwlovers.auth.dto.request.UpdateNaverRequest;
 import com.capstone.bwlovers.auth.dto.response.TokenResponse;
 import com.capstone.bwlovers.auth.dto.response.UpdateNaverResponse;
+import com.capstone.bwlovers.auth.dto.response.UserInfoResponse;
 import com.capstone.bwlovers.auth.service.AuthService;
 import com.capstone.bwlovers.global.exception.CustomException;
 import com.capstone.bwlovers.global.exception.ExceptionCode;
@@ -42,14 +43,19 @@ public class AuthController {
     }
 
     /*
+    네이버 로그인 정보 조회 (프로필 사진, 닉네임, 이메일, 전화번호)
+     */
+    @GetMapping("/users/me")
+    public ResponseEntity<UserInfoResponse> getNaverInfo(Authentication authentication) {
+        return ResponseEntity.ok(authService.getNaver(authentication));
+    }
+
+    /*
     네이버 로그인 정보 수정 (닉네임, 프로필 사진만)
      */
-    @PatchMapping("/users/naver")
-    public ResponseEntity<UpdateNaverResponse> updateNaver(@AuthenticationPrincipal OAuth2User principal,
-                                                           @RequestBody UpdateNaverRequest request) {
-        Long userId = principal.getAttribute("userId");
-        UpdateNaverResponse response = authService.updateNaver(userId, request);
-        return ResponseEntity.ok(response);
+    @PatchMapping("/users/me")
+    public ResponseEntity<UpdateNaverResponse> updateNaver(Authentication authentication, @RequestBody UpdateNaverRequest request) {
+        return ResponseEntity.ok(authService.updateNaver(authentication, request));
     }
 
     /*

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/domain/User.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/domain/User.java
@@ -1,5 +1,6 @@
 package com.capstone.bwlovers.auth.domain;
 
+import com.capstone.bwlovers.auth.dto.response.UserInfoResponse;
 import com.capstone.bwlovers.health.domain.HealthStatus;
 import com.capstone.bwlovers.pregnancy.domain.PregnancyInfo;
 import jakarta.persistence.*;
@@ -78,5 +79,12 @@ public class User {
         }
     }
 
-
+    public static UserInfoResponse toResponse(User user) {
+        return UserInfoResponse.builder()
+                .username(user.getUsername())
+                .profileImageUrl(user.getProfileImageUrl())
+                .phone(user.getPhone())
+                .email(user.getEmail())
+                .build();
+    }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/dto/response/UserInfoResponse.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/dto/response/UserInfoResponse.java
@@ -1,0 +1,15 @@
+package com.capstone.bwlovers.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserInfoResponse {
+    private String username;
+    private String profileImageUrl;
+    private String email;
+    private String phone;
+}

--- a/bwlovers/src/main/java/com/capstone/bwlovers/auth/service/AuthService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/auth/service/AuthService.java
@@ -3,10 +3,7 @@ package com.capstone.bwlovers.auth.service;
 import com.capstone.bwlovers.auth.domain.OAuthProvider;
 import com.capstone.bwlovers.auth.domain.User;
 import com.capstone.bwlovers.auth.dto.request.UpdateNaverRequest;
-import com.capstone.bwlovers.auth.dto.response.NaverUserInfoResponse;
-import com.capstone.bwlovers.auth.dto.response.NaverTokenResponse;
-import com.capstone.bwlovers.auth.dto.response.TokenResponse;
-import com.capstone.bwlovers.auth.dto.response.UpdateNaverResponse;
+import com.capstone.bwlovers.auth.dto.response.*;
 import com.capstone.bwlovers.auth.repository.UserRepository;
 import com.capstone.bwlovers.global.exception.CustomException;
 import com.capstone.bwlovers.global.exception.ExceptionCode;
@@ -124,13 +121,41 @@ public class AuthService {
     }
 
     /*
+    네이버 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public UserInfoResponse getNaver(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new CustomException(ExceptionCode.AUTH_TOKEN_INVALID);
+        }
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof User user)) {
+            throw new CustomException(ExceptionCode.AUTH_TOKEN_INVALID);
+        }
+
+        return UserInfoResponse.builder()
+                .username(user.getUsername())
+                .profileImageUrl(user.getProfileImageUrl())
+                .phone(user.getPhone())
+                .email(user.getEmail())
+                .build();
+    }
+
+    /*
     네이버 정보 수정
      */
     @Transactional
-    public UpdateNaverResponse updateNaver(Long userId, UpdateNaverRequest request) {
+    public UpdateNaverResponse updateNaver(Authentication authentication,
+                                           UpdateNaverRequest request) {
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new CustomException(ExceptionCode.AUTH_TOKEN_INVALID);
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof User user)) {
+            throw new CustomException(ExceptionCode.AUTH_TOKEN_INVALID);
+        }
 
         if (request.getUsername() != null && !request.getUsername().isBlank()) {
             user.update(request.getUsername(), user.getProfileImageUrl());
@@ -140,7 +165,10 @@ public class AuthService {
             user.update(user.getUsername(), request.getProfileImageUrl());
         }
 
-        return new UpdateNaverResponse(user.getUsername(), user.getProfileImageUrl());
+        return new UpdateNaverResponse(
+                user.getUsername(),
+                user.getProfileImageUrl()
+        );
     }
 
     /*


### PR DESCRIPTION
## 연관 이슈

close #35 

<br/>

## 설명

네이버 로그인 정보 (프로필사진, 닉네임, 이메일, 전화번호)를 조회합니다.
추가로 사용자 조회, 수정 인증 방식 개선도 하였습니다.

<br/>

## 📌 구현 기능

- [x] 네이버 로그인 정보 조회 api
- [x] 사용자 조회, 수정 인증 방식 개선

## 📷 테스트 결과
<img width="1552" height="766" alt="image" src="https://github.com/user-attachments/assets/b94db3a0-1471-496d-ad17-1416ae0f48ae" />
