### PR TITLE
feat(#34): 시뮬레이션 CRUD

### DIFF
--- a/bwlovers/src/main/java/com/capstone/bwlovers/global/exception/ClientExceptionCode.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/global/exception/ClientExceptionCode.java
@@ -66,4 +66,7 @@ public enum ClientExceptionCode {
     S3_CLIENT_ERROR,
     S3_PROFILE_IMAGE_NOT_FOUND,
     S3_DELETE_FAILED,
+
+    // simulation
+    SIMULATION_NOT_FOUND,
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/global/exception/ExceptionCode.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/global/exception/ExceptionCode.java
@@ -70,8 +70,10 @@ public enum ExceptionCode {
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, ClientExceptionCode.S3_UPLOAD_FAILED, "S3 업로드에 실패했습니다."),
     S3_CLIENT_ERROR(HttpStatus.BAD_GATEWAY, ClientExceptionCode.S3_CLIENT_ERROR, "S3 통신 중 오류가 발생했습니다."),
     S3_PROFILE_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, ClientExceptionCode.S3_PROFILE_IMAGE_NOT_FOUND, "삭제할 프로필 이미지가 존재하지 않습니다."),
-    S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, ClientExceptionCode.S3_DELETE_FAILED, "프로필 이미지 삭제에 실패했습니다.");
+    S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, ClientExceptionCode.S3_DELETE_FAILED, "프로필 이미지 삭제에 실패했습니다."),
 
+    // simulation
+    SIMULATION_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.SIMULATION_NOT_FOUND, "저장한 시뮬레이션 결과를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final ClientExceptionCode clientExceptionCode;

--- a/bwlovers/src/main/java/com/capstone/bwlovers/simulation/controller/SimulationController.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/simulation/controller/SimulationController.java
@@ -2,6 +2,9 @@ package com.capstone.bwlovers.simulation.controller;
 
 import com.capstone.bwlovers.auth.domain.User;
 import com.capstone.bwlovers.simulation.dto.request.SimulationSaveRequest;
+import com.capstone.bwlovers.simulation.dto.response.SimulationDetailListResponse;
+import com.capstone.bwlovers.simulation.dto.response.SimulationDetailResponse;
+import com.capstone.bwlovers.simulation.dto.response.SimulationListResponse;
 import com.capstone.bwlovers.simulation.dto.response.SimulationSaveResponse;
 import com.capstone.bwlovers.simulation.service.SimulationService;
 import jakarta.validation.Valid;
@@ -9,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +31,44 @@ public class SimulationController {
                                                        @Valid @RequestBody SimulationSaveRequest request) {
         Long savedId = simulationService.saveSimulationResult(user.getUserId(), request);
         return ResponseEntity.ok(SimulationSaveResponse.of(savedId, request.getResultId()));
+    }
+
+    /**
+     * 시뮬레이션 리스트 조회
+     * GET /simulations
+     */
+    @GetMapping
+    public ResponseEntity<List<SimulationListResponse>> list(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(simulationService.getSimulationList(user.getUserId()));
+    }
+
+    /**
+     * 시뮬레이션 상세 리스트 조회
+     * GET /simulations/details
+     */
+    @GetMapping("/details")
+    public ResponseEntity<List<SimulationDetailListResponse>> detailList(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(simulationService.getSimulationDetailList(user.getUserId()));
+    }
+
+    /**
+     * 시뮬레이션 상세보기
+     * GET /simulations/{simulationId}
+     */
+    @GetMapping("/{simulationId}")
+    public ResponseEntity<SimulationDetailResponse> detail(@AuthenticationPrincipal User user,
+                                                           @PathVariable Long simulationId) {
+        return ResponseEntity.ok(simulationService.getSimulationDetail(user.getUserId(), simulationId));
+    }
+
+    /**
+     * 시뮬레이션 삭제
+     * DELETE /simulations/{simulationId}
+     */
+    @DeleteMapping("/{simulationId}")
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal User user,
+                                       @PathVariable Long simulationId) {
+        simulationService.deleteSimulation(user.getUserId(), simulationId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/simulation/dto/response/SimulationDetailListResponse.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/simulation/dto/response/SimulationDetailListResponse.java
@@ -1,0 +1,22 @@
+package com.capstone.bwlovers.simulation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SimulationDetailListResponse {
+    private Long simulationId;
+    private String productName;
+    private LocalDateTime createdAt;
+
+    public static SimulationDetailListResponse of(Long simulationId, String productName, LocalDateTime createdAt) {
+        return SimulationDetailListResponse.builder()
+                .simulationId(simulationId)
+                .productName(productName)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/bwlovers/src/main/java/com/capstone/bwlovers/simulation/dto/response/SimulationDetailResponse.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/simulation/dto/response/SimulationDetailResponse.java
@@ -1,0 +1,57 @@
+package com.capstone.bwlovers.simulation.dto.response;
+
+import com.capstone.bwlovers.simulation.domain.Simulation;
+import com.capstone.bwlovers.simulation.domain.SimulationContract;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class SimulationDetailResponse {
+
+    private Long simulationId;
+    private String resultId;
+
+    private String insuranceCompany;
+    private String productName;
+
+    private String question;
+    private String result;
+
+    private LocalDateTime createdAt;
+
+    private List<ContractResponse> contracts;
+
+    @Getter
+    @Builder
+    public static class ContractResponse {
+        private String contractName;
+        private Long pageNumber;
+
+        public static ContractResponse from(SimulationContract c) {
+            return ContractResponse.builder()
+                    .contractName(c.getContractName())
+                    .pageNumber(c.getPageNumber())
+                    .build();
+        }
+    }
+
+    public static SimulationDetailResponse from(Simulation s) {
+        List<ContractResponse> contractResponses = (s.getContracts() == null) ? List.of()
+                : s.getContracts().stream().map(ContractResponse::from).toList();
+
+        return SimulationDetailResponse.builder()
+                .simulationId(s.getId())
+                .resultId(s.getResultId())
+                .insuranceCompany(s.getInsuranceCompany())
+                .productName(s.getProductName())
+                .question(s.getQuestion())
+                .result(s.getResult())
+                .createdAt(s.getCreatedAt())
+                .contracts(contractResponses)
+                .build();
+    }
+}

--- a/bwlovers/src/main/java/com/capstone/bwlovers/simulation/dto/response/SimulationListResponse.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/simulation/dto/response/SimulationListResponse.java
@@ -1,0 +1,20 @@
+package com.capstone.bwlovers.simulation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SimulationListResponse {
+    private Long simulationId;
+    private LocalDateTime createdAt;
+
+    public static SimulationListResponse of(Long simulationId, LocalDateTime createdAt) {
+        return SimulationListResponse.builder()
+                .simulationId(simulationId)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/bwlovers/src/main/java/com/capstone/bwlovers/simulation/repository/SimulationRepository.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/simulation/repository/SimulationRepository.java
@@ -1,11 +1,18 @@
 package com.capstone.bwlovers.simulation.repository;
 
 import com.capstone.bwlovers.simulation.domain.Simulation;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SimulationRepository extends JpaRepository<Simulation, Long> {
     boolean existsByResultId(String resultId);
     Optional<Simulation> findByResultId(String resultId);
+    List<Simulation> findByUser_UserIdOrderByCreatedAtAsc(Long userId);
+    @EntityGraph(attributePaths = "contracts")
+    Optional<Simulation> findByIdAndUser_UserId(Long simulationId, Long userId);
+    void deleteByIdAndUser_UserId(Long simulationId, Long userId);
+    boolean existsByIdAndUser_UserId(Long simulationId, Long userId);
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/simulation/service/SimulationService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/simulation/service/SimulationService.java
@@ -9,10 +9,15 @@ import com.capstone.bwlovers.global.exception.ExceptionCode;
 import com.capstone.bwlovers.simulation.domain.Simulation;
 import com.capstone.bwlovers.simulation.domain.SimulationContract;
 import com.capstone.bwlovers.simulation.dto.request.SimulationSaveRequest;
+import com.capstone.bwlovers.simulation.dto.response.SimulationDetailListResponse;
+import com.capstone.bwlovers.simulation.dto.response.SimulationDetailResponse;
+import com.capstone.bwlovers.simulation.dto.response.SimulationListResponse;
 import com.capstone.bwlovers.simulation.repository.SimulationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -84,11 +89,55 @@ public class SimulationService {
         return simulationRepository.save(simulation).getId();
     }
 
+    /**
+     * 시뮬레이션 리스트 조회
+     */
+    @Transactional(readOnly = true)
+    public List<SimulationListResponse> getSimulationList(Long userId) {
+        return simulationRepository.findByUser_UserIdOrderByCreatedAtAsc(userId).stream()
+                .map(s -> SimulationListResponse.of(s.getId(), s.getCreatedAt()))
+                .toList();
+    }
+
+    /**
+     * 시뮬레이션 상세 리스트 조회
+     */
+    @Transactional(readOnly = true)
+    public List<SimulationDetailListResponse> getSimulationDetailList(Long userId) {
+        return simulationRepository.findByUser_UserIdOrderByCreatedAtAsc(userId).stream()
+                .map(s -> SimulationDetailListResponse.of(s.getId(), s.getProductName(), s.getCreatedAt()))
+                .toList();
+    }
+
+    /**
+     * 시뮬레이션 상세보기
+     */
+    @Transactional(readOnly = true)
+    public SimulationDetailResponse getSimulationDetail(Long userId, Long simulationId) {
+        var simulation = simulationRepository.findByIdAndUser_UserId(simulationId, userId)
+                .orElseThrow(() -> new CustomException(ExceptionCode.SIMULATION_NOT_FOUND));
+
+        return SimulationDetailResponse.from(simulation);
+    }
+
     private boolean isBlank(String s) {
         return s == null || s.isBlank();
     }
 
     private String nullToEmpty(String s) {
         return s == null ? "" : s;
+    }
+
+    /**
+     * 시뮬레이션 삭제
+     */
+    @Transactional
+    public void deleteSimulation(Long userId, Long simulationId) {
+        boolean exists = simulationRepository.existsByIdAndUser_UserId(simulationId, userId);
+        if (!exists) {
+            throw new CustomException(ExceptionCode.SIMULATION_NOT_FOUND);
+        }
+
+        simulationRepository.deleteByIdAndUser_UserId(simulationId, userId);
     }
 }


### PR DESCRIPTION
## 연관 이슈

close #34 

<br/>

## 설명

내 시뮬레이션 리스트 조회, 상세 리스트 조회, 상세 조회, 삭제 기능입니다.

<br/>

## 📌 구현 기능

- [x] 저장한 시뮬레이션에 대한 CRUD
- [x] 관련 예외 처리 및 에러 핸들링

## 📷 테스트 결과
<img width="1576" height="864" alt="image" src="https://github.com/user-attachments/assets/963be9aa-3632-4a3a-ab61-b9f11b31e14e" />
<img width="1576" height="864" alt="image" src="https://github.com/user-attachments/assets/d29faccc-9a72-40a1-a8c7-a89dd96d0543" />
<img width="1552" height="1286" alt="image" src="https://github.com/user-attachments/assets/e849fbf1-1453-4a4a-aebc-7feac0903453" />
<img width="1582" height="558" alt="image" src="https://github.com/user-attachments/assets/67f4bd3a-ea2f-42f4-8ec5-c702e937d74a" />




<br/>
  
## ⚠️ 참고 사항 및 주의할 점
- 해당 결과는 단순 테스트를 위해 무작위로 수동 작성하여 넣은 데이터입니다.
