### PR TITLE
feat: 시뮬레이션 분석 결과에 보험 스냅샷 정보 캐싱 추가

### DIFF
--- a/bwlovers/src/main/java/com/capstone/bwlovers/ai/analysis/dto/response/AnalysisResultResponse.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/ai/analysis/dto/response/AnalysisResultResponse.java
@@ -20,6 +20,18 @@ public class AnalysisResultResponse {
     @JsonProperty("product_name")
     private String productName;
 
+    @JsonProperty("is_long_term")
+    private Boolean longTerm;
+
+    @JsonProperty("sum_insured")
+    private Long sumInsured;
+
+    @JsonProperty("monthly_cost")
+    private String monthlyCost;
+
+    @JsonProperty("memo")
+    private String memo;
+
     @JsonProperty("special_contracts")
     private List<SpecialContract> specialContracts;
 
@@ -58,6 +70,10 @@ public class AnalysisResultResponse {
                 .resultId(cb.getResultId())
                 .insuranceCompany(cb.getInsuranceCompany())
                 .productName(cb.getProductName())
+                .longTerm(null)
+                .sumInsured(null)
+                .monthlyCost(null)
+                .memo(null)
                 .specialContracts(mapped)
                 .question(cb.getQuestion())
                 .result(cb.getResult())

--- a/bwlovers/src/main/java/com/capstone/bwlovers/ai/analysis/service/AnalysisCacheService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/ai/analysis/service/AnalysisCacheService.java
@@ -42,6 +42,23 @@ public class AnalysisCacheService {
         }
     }
 
+    public void saveSourceInsuranceId(String resultId, Long insuranceId, long ttlSec) {
+        String key = AiCacheKeys.simulationSourceInsuranceKey(resultId);
+        try {
+            stringRedisTemplate.opsForValue().set(
+                    key,
+                    String.valueOf(insuranceId),
+                    Duration.ofSeconds(ttlSec)
+            );
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[REDIS_CONNECTION_FAILED] key={}", key, e);
+            throw new CustomException(ExceptionCode.REDIS_CONNECTION_FAILED);
+        } catch (DataAccessException e) {
+            log.warn("[REDIS_SAVE_FAILED] key={}", key, e);
+            throw new CustomException(ExceptionCode.REDIS_SAVE_FAILED);
+        }
+    }
+
     public AnalysisResultResponse getResult(String resultId) {
         String key = AiCacheKeys.simulationResultKey(resultId);
         try {
@@ -70,12 +87,32 @@ public class AnalysisCacheService {
         }
     }
 
-    public void delete(String resultId) {
-        String key = AiCacheKeys.simulationResultKey(resultId);
+    public Long getSourceInsuranceId(String resultId) {
+        String key = AiCacheKeys.simulationSourceInsuranceKey(resultId);
         try {
-            stringRedisTemplate.delete(key);
+            String raw = stringRedisTemplate.opsForValue().get(key);
+            if (raw == null || raw.isBlank()) {
+                return null;
+            }
+            return Long.parseLong(raw);
+        } catch (NumberFormatException e) {
+            log.warn("[REDIS_INVALID_SOURCE_INSURANCE_ID] key={}", key, e);
+            return null;
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[REDIS_CONNECTION_FAILED] key={}", key, e);
+            throw new CustomException(ExceptionCode.REDIS_CONNECTION_FAILED);
+        } catch (DataAccessException e) {
+            log.warn("[REDIS_READ_FAILED] key={}", key, e);
+            throw new CustomException(ExceptionCode.REDIS_READ_FAILED);
+        }
+    }
+
+    public void delete(String resultId) {
+        try {
+            stringRedisTemplate.delete(AiCacheKeys.simulationResultKey(resultId));
+            stringRedisTemplate.delete(AiCacheKeys.simulationSourceInsuranceKey(resultId));
         } catch (Exception e) {
-            log.warn("[REDIS_DELETE_FAILED] key={}", key, e);
+            log.warn("[REDIS_DELETE_FAILED] resultId={}", resultId, e);
         }
     }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/ai/analysis/service/AnalysisService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/ai/analysis/service/AnalysisService.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -30,6 +31,7 @@ import java.util.List;
 public class AnalysisService {
 
     private static final long DEFAULT_TTL_SEC = 600L;
+    private static final long DEFAULT_SNAPSHOT_TTL_SEC = 2_592_000L;
 
     private final UserRepository userRepository;
     private final WebClient aiWebClient;
@@ -39,6 +41,9 @@ public class AnalysisService {
     private final SpecialContractRepository specialContractRepository;
 
     private final ObjectMapper objectMapper;
+
+    @Value("${analysis.simulation.cache-ttl-seconds:2592000}")
+    private long simulationCacheTtlSec;
 
     public AnalysisCreateResponse requestSimulation(Long userId, SimulationRunRequest runReq) {
 
@@ -102,12 +107,22 @@ public class AnalysisService {
             throw new CustomException(ExceptionCode.AI_SERVER_5XX);
         }
 
-        String resultId = tryParseAndCacheIfPossible(raw);
-        if (isBlank(resultId)) {
+        ParsedSimulationResponse parsed = tryParseSimulationResponse(raw);
+        if (parsed == null || isBlank(parsed.resultId())) {
             throw new CustomException(ExceptionCode.AI_SERVER_5XX);
         }
 
-        return AnalysisCreateResponse.of(resultId);
+        analysisCacheService.saveSourceInsuranceId(
+                parsed.resultId(),
+                runReq.getInsuranceId(),
+                resolveSnapshotTtlSec(null)
+        );
+
+        if (parsed.callback() != null && !isBlank(parsed.callback().getResult())) {
+            cacheCallbackResult(parsed.callback());
+        }
+
+        return AnalysisCreateResponse.of(parsed.resultId());
     }
 
     public void cacheCallbackResult(AnalysisCallbackRequest callback) {
@@ -116,12 +131,17 @@ public class AnalysisService {
             throw new CustomException(ExceptionCode.AI_INVALID_REQUEST);
         }
 
-        long ttlSec = (callback.getExpiresInSec() == null ? DEFAULT_TTL_SEC : callback.getExpiresInSec());
+        long ttlSec = resolveSnapshotTtlSec(callback.getExpiresInSec());
 
-        AnalysisResultResponse result = AnalysisResultResponse.fromCallback(callback);
+        AnalysisResultResponse result = enrichSnapshot(AnalysisResultResponse.fromCallback(callback), callback);
         analysisCacheService.saveResult(callback.getResultId(), result, ttlSec);
 
-        log.info("[SIMULATION CALLBACK CACHED] resultId={}, ttlSec={}", callback.getResultId(), ttlSec);
+        log.info(
+                "[SIMULATION CALLBACK CACHED] resultId={}, ttlSec={}, enriched={}",
+                callback.getResultId(),
+                ttlSec,
+                result.getSumInsured() != null
+        );
     }
 
     public AnalysisResultResponse getSimulationResult(String resultId) {
@@ -133,7 +153,12 @@ public class AnalysisService {
         if (cached == null) {
             throw new CustomException(ExceptionCode.AI_RESULT_NOT_FOUND);
         }
-        return cached;
+
+        AnalysisResultResponse enriched = enrichSnapshotIfMissing(cached);
+        if (enriched != cached) {
+            analysisCacheService.saveResult(resultId, enriched, resolveSnapshotTtlSec(null));
+        }
+        return enriched;
     }
 
     // =========================================================
@@ -149,17 +174,14 @@ public class AnalysisService {
         }
     }
 
-    private String tryParseAndCacheIfPossible(String raw) {
+    private ParsedSimulationResponse tryParseSimulationResponse(String raw) {
         ObjectMapper lenient = objectMapper.copy()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         try {
             AnalysisCallbackRequest cb = lenient.readValue(raw, AnalysisCallbackRequest.class);
             if (!isBlank(cb.getResultId())) {
-                if (!isBlank(cb.getResult())) {
-                    cacheCallbackResult(cb);
-                }
-                return cb.getResultId();
+                return new ParsedSimulationResponse(cb.getResultId(), cb);
             }
         } catch (Exception ignore) {
             // fallback 시도함
@@ -167,11 +189,104 @@ public class AnalysisService {
 
         try {
             SimulationAck ack = lenient.readValue(raw, SimulationAck.class);
-            return ack.resultId;
+            return new ParsedSimulationResponse(ack.resultId, null);
         } catch (Exception e) {
             log.error("[AI /ai/simulation PARSE ERROR] raw={}", raw, e);
             return null;
         }
+    }
+
+    private AnalysisResultResponse enrichSnapshot(AnalysisResultResponse result, AnalysisCallbackRequest callback) {
+        InsuranceProduct insurance = resolveSourceInsurance(callback);
+        if (insurance == null) {
+            log.warn(
+                    "[SIMULATION SNAPSHOT SOURCE NOT FOUND] resultId={}, insuranceCompany={}, productName={}",
+                    callback.getResultId(),
+                    callback.getInsuranceCompany(),
+                    callback.getProductName()
+            );
+            return result;
+        }
+
+        return AnalysisResultResponse.builder()
+                .resultId(result.getResultId())
+                .insuranceCompany(result.getInsuranceCompany())
+                .productName(result.getProductName())
+                .longTerm(insurance.isLongTerm())
+                .sumInsured(insurance.getSumInsured())
+                .monthlyCost(nullToEmpty(insurance.getMonthlyCost()))
+                .memo(nullToEmpty(insurance.getMemo()))
+                .specialContracts(result.getSpecialContracts())
+                .question(result.getQuestion())
+                .result(result.getResult())
+                .build();
+    }
+
+    private AnalysisResultResponse enrichSnapshotIfMissing(AnalysisResultResponse result) {
+        if (result == null || hasSnapshot(result)) {
+            return result;
+        }
+
+        InsuranceProduct insurance = resolveSourceInsurance(
+                result.getResultId(),
+                result.getInsuranceCompany(),
+                result.getProductName()
+        );
+        if (insurance == null) {
+            return result;
+        }
+
+        return AnalysisResultResponse.builder()
+                .resultId(result.getResultId())
+                .insuranceCompany(result.getInsuranceCompany())
+                .productName(result.getProductName())
+                .longTerm(insurance.isLongTerm())
+                .sumInsured(insurance.getSumInsured())
+                .monthlyCost(nullToEmpty(insurance.getMonthlyCost()))
+                .memo(nullToEmpty(insurance.getMemo()))
+                .specialContracts(result.getSpecialContracts())
+                .question(result.getQuestion())
+                .result(result.getResult())
+                .build();
+    }
+
+    private InsuranceProduct resolveSourceInsurance(AnalysisCallbackRequest callback) {
+        return resolveSourceInsurance(
+                callback.getResultId(),
+                callback.getInsuranceCompany(),
+                callback.getProductName()
+        );
+    }
+
+    private InsuranceProduct resolveSourceInsurance(String resultId, String insuranceCompany, String productName) {
+        Long insuranceId = analysisCacheService.getSourceInsuranceId(resultId);
+        if (insuranceId != null) {
+            return insuranceProductRepository.findById(insuranceId).orElse(null);
+        }
+
+        if (isBlank(insuranceCompany) || isBlank(productName)) {
+            return null;
+        }
+
+        return insuranceProductRepository
+                .findTopByInsuranceCompanyAndProductNameOrderByCreatedAtDesc(
+                        insuranceCompany,
+                        productName
+                )
+                .orElse(null);
+    }
+
+    private boolean hasSnapshot(AnalysisResultResponse result) {
+        return result.getLongTerm() != null
+                && result.getSumInsured() != null
+                && result.getMonthlyCost() != null
+                && result.getMemo() != null;
+    }
+
+    private long resolveSnapshotTtlSec(Integer callbackTtlSec) {
+        long baseTtl = simulationCacheTtlSec > 0 ? simulationCacheTtlSec : DEFAULT_SNAPSHOT_TTL_SEC;
+        long callbackTtl = callbackTtlSec == null ? DEFAULT_TTL_SEC : callbackTtlSec.longValue();
+        return Math.max(baseTtl, callbackTtl);
     }
 
     private boolean isBlank(String s) {
@@ -186,5 +301,11 @@ public class AnalysisService {
     private static class SimulationAck {
         public String resultId;
         public Integer expiresInSec;
+    }
+
+    private record ParsedSimulationResponse(
+            String resultId,
+            AnalysisCallbackRequest callback
+    ) {
     }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/ai/common/cache/AiCacheKeys.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/ai/common/cache/AiCacheKeys.java
@@ -27,18 +27,26 @@ public final class AiCacheKeys {
 
     /**
      * 분석 리스트 키 생성
-     * 결과: ai:v2:simulation:result:{simulationId}
+     * 결과: ai:v2:simulation:result:{resultId}
      */
-    public static String simulationResultKey(String simulationId) {
-        return SIMULATION_PREFIX + "result:" + simulationId;
+    public static String simulationResultKey(String resultId) {
+        return SIMULATION_PREFIX + "result:" + resultId;
+    }
+
+    /**
+     * 분석 요청 원본 보험 키 생성
+     * 결과: ai:v2:simulation:source-insurance:{resultId}
+     */
+    public static String simulationSourceInsuranceKey(String resultId) {
+        return SIMULATION_PREFIX + "source-insurance:" + resultId;
     }
 
     /**
      * 분석 결과 상세 키 생성
-     * 결과: ai:v2:simulation:status:{simulationId}
+     * 결과: ai:v2:simulation:status:{resultId}
      */
-    public static String simulationStatusKey(String simulationId) {
-        return SIMULATION_PREFIX + "status:" + simulationId;
+    public static String simulationStatusKey(String resultId) {
+        return SIMULATION_PREFIX + "status:" + resultId;
     }
 
     // OCR Job

--- a/bwlovers/src/main/java/com/capstone/bwlovers/insurance/repository/InsuranceProductRepository.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/insurance/repository/InsuranceProductRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 public interface InsuranceProductRepository extends JpaRepository<InsuranceProduct, Long> {
     Optional<InsuranceProduct> findByUser_UserIdAndResultIdAndItemId(Long userId, String resultId, String itemId);
+    Optional<InsuranceProduct> findTopByInsuranceCompanyAndProductNameOrderByCreatedAtDesc(String insuranceCompany, String productName);
     List<InsuranceProduct> findAllByUser_UserIdOrderByCreatedAtDesc(Long userId);
 
     // N+1 문제 방지를 위해 Fetch Join이 적용된 레포지토리 메서드

--- a/bwlovers/src/main/java/com/capstone/bwlovers/simulation/dto/response/SimulationDetailResponse.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/simulation/dto/response/SimulationDetailResponse.java
@@ -1,5 +1,6 @@
 package com.capstone.bwlovers.simulation.dto.response;
 
+import com.capstone.bwlovers.ai.analysis.dto.response.AnalysisResultResponse;
 import com.capstone.bwlovers.simulation.domain.Simulation;
 import com.capstone.bwlovers.simulation.domain.SimulationContract;
 import lombok.Builder;
@@ -17,6 +18,10 @@ public class SimulationDetailResponse {
 
     private String insuranceCompany;
     private String productName;
+    private Boolean longTerm;
+    private Long sumInsured;
+    private String monthlyCost;
+    private String memo;
 
     private String question;
     private String result;
@@ -40,18 +45,46 @@ public class SimulationDetailResponse {
     }
 
     public static SimulationDetailResponse from(Simulation s) {
-        List<ContractResponse> contractResponses = (s.getContracts() == null) ? List.of()
-                : s.getContracts().stream().map(ContractResponse::from).toList();
+        return from(s, null);
+    }
+
+    public static SimulationDetailResponse from(Simulation s, AnalysisResultResponse cached) {
+        List<ContractResponse> contractResponses = getContractResponses(s, cached);
 
         return SimulationDetailResponse.builder()
                 .simulationId(s.getId())
                 .resultId(s.getResultId())
-                .insuranceCompany(s.getInsuranceCompany())
-                .productName(s.getProductName())
-                .question(s.getQuestion())
-                .result(s.getResult())
+                .insuranceCompany(prefer(cached == null ? null : cached.getInsuranceCompany(), s.getInsuranceCompany()))
+                .productName(prefer(cached == null ? null : cached.getProductName(), s.getProductName()))
+                .longTerm(cached == null ? null : cached.getLongTerm())
+                .sumInsured(cached == null ? null : cached.getSumInsured())
+                .monthlyCost(cached == null ? null : cached.getMonthlyCost())
+                .memo(cached == null ? null : cached.getMemo())
+                .question(prefer(cached == null ? null : cached.getQuestion(), s.getQuestion()))
+                .result(prefer(cached == null ? null : cached.getResult(), s.getResult()))
                 .createdAt(s.getCreatedAt())
                 .contracts(contractResponses)
                 .build();
+    }
+
+    private static List<ContractResponse> getContractResponses(Simulation s, AnalysisResultResponse cached) {
+        if (cached != null && cached.getSpecialContracts() != null) {
+            return cached.getSpecialContracts().stream()
+                    .map(contract -> ContractResponse.builder()
+                            .contractName(contract.getContractName())
+                            .pageNumber(contract.getPageNumber() == null ? null : contract.getPageNumber().longValue())
+                            .build())
+                    .toList();
+        }
+
+        return (s.getContracts() == null) ? List.of()
+                : s.getContracts().stream().map(ContractResponse::from).toList();
+    }
+
+    private static String prefer(String cachedValue, String fallbackValue) {
+        if (cachedValue == null || cachedValue.isBlank()) {
+            return fallbackValue;
+        }
+        return cachedValue;
     }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/simulation/service/SimulationService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/simulation/service/SimulationService.java
@@ -114,10 +114,11 @@ public class SimulationService {
      */
     @Transactional(readOnly = true)
     public SimulationDetailResponse getSimulationDetail(Long userId, Long simulationId) {
-        var simulation = simulationRepository.findByIdAndUser_UserId(simulationId, userId)
+        Simulation simulation = simulationRepository.findByIdAndUser_UserId(simulationId, userId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.SIMULATION_NOT_FOUND));
 
-        return SimulationDetailResponse.from(simulation);
+        AnalysisResultResponse cached = analysisService.getSimulationResult(simulation.getResultId());
+        return SimulationDetailResponse.from(simulation, cached);
     }
 
     private boolean isBlank(String s) {


### PR DESCRIPTION
## 설명

AI 시뮬레이션 콜백 수신 시 보험 정보를 조회한 뒤 스냅샷 값을 함께 붙여 Redis에 저장하도록 변경했습니다.
이후 시뮬레이션 결과 조회와 상세 조회에서는 Redis에 저장된 분석 결과를 기준으로 `is_long_term`, `sum_insured`, `monthly_cost`, `memo` 값을 함께 반환합니다.

<br/>

## 📌 구현 기능

- [x] AI 시뮬레이션 콜백 수신 시 보험 상품 정보를 조회해 스냅샷을 붙여 Redis에 저장
- [x] 완성된 `AnalysisResultResponse`를 Redis에 저장하도록 분석 캐시 흐름 수정
- [x] 시뮬레이션 상세 조회 응답에 `is_long_term`, `sum_insured`, `monthly_cost`, `memo` 포함

## 📷 테스트 결과
시뮬레이션 분석 결과 응답에 is_long_term, sum_insured, monthly_cost, memo를 포함시켰습니다.

- 내 시뮬레이션 결과 상세 조회
  <img width="782" height="641" alt="image" src="https://github.com/user-attachments/assets/3609355d-4ddb-48b5-847b-c10d4742b70f" />

- 시뮬레이션 결과 조회
  <img width="773" height="637" alt="image" src="https://github.com/user-attachments/assets/6874b91b-54fb-4bae-9752-e6e644fbaf33" />


<br/>

## ⚠️ 어려웠던 점과 해결 과정

- AI 콜백 payload에는 사용자/보험 식별 정보가 부족해 어떤 보험 데이터로 스냅샷을 붙일지 애매한 문제가 있었습니다.
  -> 그래서 시뮬레이션 요청 시점에 resultId -> insuranceId 매핑을 Redis에 저장하고, 콜백 시 해당 보험을 조회해 snapshot 값을 붙이도록 처리했습니다.

