### PR TITLE
feat: Redis 장애에 대비한 cache-aside 폴백 적용

### DIFF
--- a/bwlovers/src/main/java/com/capstone/bwlovers/ai/analysis/service/AnalysisCacheService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/ai/analysis/service/AnalysisCacheService.java
@@ -115,4 +115,44 @@ public class AnalysisCacheService {
             log.warn("[REDIS_DELETE_FAILED] resultId={}", resultId, e);
         }
     }
+
+    public void saveResultSafely(String resultId, AnalysisResultResponse result, long ttlSec) {
+        try {
+            saveResult(resultId, result, ttlSec);
+        } catch (CustomException e) {
+            log.warn("[SIMULATION_CACHE_SAVE_BYPASS] resultId={}, ttlSec={}", resultId, ttlSec, e);
+        }
+    }
+
+    public void saveSourceInsuranceIdSafely(String resultId, Long insuranceId, long ttlSec) {
+        try {
+            saveSourceInsuranceId(resultId, insuranceId, ttlSec);
+        } catch (CustomException e) {
+            log.warn(
+                    "[SIMULATION_SOURCE_CACHE_SAVE_BYPASS] resultId={}, insuranceId={}, ttlSec={}",
+                    resultId,
+                    insuranceId,
+                    ttlSec,
+                    e
+            );
+        }
+    }
+
+    public AnalysisResultResponse findResultSafely(String resultId) {
+        try {
+            return getResult(resultId);
+        } catch (CustomException e) {
+            log.warn("[SIMULATION_CACHE_READ_BYPASS] resultId={}", resultId, e);
+            return null;
+        }
+    }
+
+    public Long findSourceInsuranceIdSafely(String resultId) {
+        try {
+            return getSourceInsuranceId(resultId);
+        } catch (CustomException e) {
+            log.warn("[SIMULATION_SOURCE_CACHE_READ_BYPASS] resultId={}", resultId, e);
+            return null;
+        }
+    }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/ai/analysis/service/AnalysisService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/ai/analysis/service/AnalysisService.java
@@ -12,6 +12,8 @@ import com.capstone.bwlovers.insurance.domain.InsuranceProduct;
 import com.capstone.bwlovers.insurance.domain.SpecialContract;
 import com.capstone.bwlovers.insurance.repository.InsuranceProductRepository;
 import com.capstone.bwlovers.insurance.repository.SpecialContractRepository;
+import com.capstone.bwlovers.simulation.domain.Simulation;
+import com.capstone.bwlovers.simulation.repository.SimulationRepository;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,6 +42,7 @@ public class AnalysisService {
 
     private final InsuranceProductRepository insuranceProductRepository;
     private final SpecialContractRepository specialContractRepository;
+    private final SimulationRepository simulationRepository;
 
     private final ObjectMapper objectMapper;
 
@@ -113,7 +116,7 @@ public class AnalysisService {
             throw new CustomException(ExceptionCode.AI_SERVER_5XX);
         }
 
-        analysisCacheService.saveSourceInsuranceId(
+        analysisCacheService.saveSourceInsuranceIdSafely(
                 parsed.resultId(),
                 runReq.getInsuranceId(),
                 resolveSnapshotTtlSec(null)
@@ -150,15 +153,34 @@ public class AnalysisService {
             throw new CustomException(ExceptionCode.AI_INVALID_REQUEST);
         }
 
-        AnalysisResultResponse cached = analysisCacheService.getResult(resultId);
-        if (cached == null) {
+        AnalysisResultResponse cached = null;
+        CustomException cacheReadFailure = null;
+
+        try {
+            cached = analysisCacheService.getResult(resultId);
+        } catch (CustomException e) {
+            log.warn("[SIMULATION_CACHE_READ_BYPASS] resultId={}", resultId, e);
+            cacheReadFailure = e;
+        }
+
+        if (cached != null) {
+            AnalysisResultResponse enriched = enrichSnapshotIfMissing(cached);
+            if (enriched != cached) {
+                analysisCacheService.saveResultSafely(resultId, enriched, resolveSnapshotTtlSec(null));
+            }
+            return enriched;
+        }
+
+        AnalysisResultResponse persisted = loadSimulationResultFromDatabase(resultId);
+        if (persisted == null) {
+            if (cacheReadFailure != null) {
+                throw cacheReadFailure;
+            }
             throw new CustomException(ExceptionCode.AI_RESULT_NOT_FOUND);
         }
 
-        AnalysisResultResponse enriched = enrichSnapshotIfMissing(cached);
-        if (enriched != cached) {
-            analysisCacheService.saveResult(resultId, enriched, resolveSnapshotTtlSec(null));
-        }
+        AnalysisResultResponse enriched = enrichSnapshotIfMissing(persisted);
+        analysisCacheService.saveResultSafely(resultId, enriched, resolveSnapshotTtlSec(null));
         return enriched;
     }
 
@@ -260,7 +282,7 @@ public class AnalysisService {
     }
 
     private InsuranceProduct resolveSourceInsurance(String resultId, String insuranceCompany, String productName) {
-        Long insuranceId = analysisCacheService.getSourceInsuranceId(resultId);
+        Long insuranceId = analysisCacheService.findSourceInsuranceIdSafely(resultId);
         if (insuranceId != null) {
             return insuranceProductRepository.findById(insuranceId).orElse(null);
         }
@@ -282,6 +304,36 @@ public class AnalysisService {
                 && result.getSumInsured() != null
                 && result.getMonthlyCost() != null
                 && result.getMemo() != null;
+    }
+
+    private AnalysisResultResponse loadSimulationResultFromDatabase(String resultId) {
+        return simulationRepository.findWithContractsByResultId(resultId)
+                .map(this::toAnalysisResultResponse)
+                .orElse(null);
+    }
+
+    private AnalysisResultResponse toAnalysisResultResponse(Simulation simulation) {
+        return AnalysisResultResponse.builder()
+                .resultId(simulation.getResultId())
+                .insuranceCompany(simulation.getInsuranceCompany())
+                .productName(simulation.getProductName())
+                .longTerm(null)
+                .sumInsured(null)
+                .monthlyCost(null)
+                .memo(null)
+                .specialContracts(
+                        simulation.getContracts() == null
+                                ? List.of()
+                                : simulation.getContracts().stream()
+                                .map(contract -> AnalysisResultResponse.SpecialContract.of(
+                                        contract.getContractName(),
+                                        contract.getPageNumber() == null ? null : contract.getPageNumber().intValue()
+                                ))
+                                .toList()
+                )
+                .question(simulation.getQuestion())
+                .result(simulation.getResult())
+                .build();
     }
 
     private long resolveSnapshotTtlSec(Integer callbackTtlSec) {

--- a/bwlovers/src/main/java/com/capstone/bwlovers/ai/recommendation/controller/RecommendationController.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/ai/recommendation/controller/RecommendationController.java
@@ -3,11 +3,8 @@ package com.capstone.bwlovers.ai.recommendation.controller;
 import com.capstone.bwlovers.ai.recommendation.dto.request.RecommendationCallbackRequest;
 import com.capstone.bwlovers.ai.recommendation.dto.response.RecommendationListResponse;
 import com.capstone.bwlovers.ai.recommendation.dto.response.RecommendationResponse;
-import com.capstone.bwlovers.ai.recommendation.service.RecommendationCacheService;
 import com.capstone.bwlovers.ai.recommendation.service.RecommendationService;
 import com.capstone.bwlovers.auth.domain.User;
-import com.capstone.bwlovers.global.exception.CustomException;
-import com.capstone.bwlovers.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -22,7 +19,6 @@ import org.springframework.web.bind.annotation.*;
 public class RecommendationController {
 
     private final RecommendationService recommendationService;
-    private final RecommendationCacheService recommendationCacheService;
 
     /**
      * 추천 요청 POST /ai/recommend
@@ -38,11 +34,7 @@ public class RecommendationController {
     @GetMapping("/recommend/{resultId}")
     public RecommendationListResponse getListFromRedis(@AuthenticationPrincipal User user,
                                                        @PathVariable String resultId) {
-        RecommendationListResponse cached = recommendationCacheService.getList(resultId);
-        if (cached == null) {
-            throw new CustomException(ExceptionCode.AI_RESULT_NOT_FOUND);
-        }
-        return cached;
+        return recommendationService.getRecommendationList(resultId);
     }
 
     /**
@@ -52,12 +44,6 @@ public class RecommendationController {
     public RecommendationResponse getDetail(@AuthenticationPrincipal User user,
                                             @PathVariable String resultId,
                                             @PathVariable String itemId) {
-
-        RecommendationResponse cached = recommendationCacheService.getDetail(resultId, itemId);
-        if (cached != null) {
-            return cached;
-        }
-
         return recommendationService.fetchAiResultDetail(user.getUserId(), resultId, itemId);
     }
 

--- a/bwlovers/src/main/java/com/capstone/bwlovers/ai/recommendation/service/RecommendationCacheService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/ai/recommendation/service/RecommendationCacheService.java
@@ -8,6 +8,7 @@ import com.capstone.bwlovers.global.exception.ExceptionCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RecommendationCacheService {
@@ -77,6 +79,46 @@ public class RecommendationCacheService {
             throw new CustomException(ExceptionCode.JSON_SERIALIZATION_FAILED);
         } catch (DataAccessException e) {
             throw new CustomException(ExceptionCode.REDIS_READ_FAILED);
+        }
+    }
+
+    public void saveListSafely(String resultId, RecommendationListResponse list, long ttlSec) {
+        try {
+            saveList(resultId, list, ttlSec);
+        } catch (CustomException e) {
+            log.warn("[RECOMMENDATION_CACHE_SAVE_BYPASS] resultId={}, ttlSec={}", resultId, ttlSec, e);
+        }
+    }
+
+    public void saveDetailSafely(String resultId, String itemId, RecommendationResponse detail, long ttlSec) {
+        try {
+            saveDetail(resultId, itemId, detail, ttlSec);
+        } catch (CustomException e) {
+            log.warn(
+                    "[RECOMMENDATION_CACHE_SAVE_BYPASS] resultId={}, itemId={}, ttlSec={}",
+                    resultId,
+                    itemId,
+                    ttlSec,
+                    e
+            );
+        }
+    }
+
+    public RecommendationListResponse findListSafely(String resultId) {
+        try {
+            return getList(resultId);
+        } catch (CustomException e) {
+            log.warn("[RECOMMENDATION_CACHE_READ_BYPASS] resultId={}", resultId, e);
+            return null;
+        }
+    }
+
+    public RecommendationResponse findDetailSafely(String resultId, String itemId) {
+        try {
+            return getDetail(resultId, itemId);
+        } catch (CustomException e) {
+            log.warn("[RECOMMENDATION_CACHE_READ_BYPASS] resultId={}, itemId={}", resultId, itemId, e);
+            return null;
         }
     }
 }

--- a/bwlovers/src/main/java/com/capstone/bwlovers/ai/recommendation/service/RecommendationService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/ai/recommendation/service/RecommendationService.java
@@ -13,7 +13,6 @@ import com.capstone.bwlovers.global.exception.CustomException;
 import com.capstone.bwlovers.global.exception.ExceptionCode;
 import com.capstone.bwlovers.health.domain.HealthStatus;
 import com.capstone.bwlovers.health.repository.HealthStatusRepository;
-import com.capstone.bwlovers.insurance.repository.InsuranceProductRepository;
 import com.capstone.bwlovers.pregnancy.domain.PregnancyInfo;
 import com.capstone.bwlovers.pregnancy.repository.PregnancyInfoRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,7 +41,6 @@ public class RecommendationService {
 
     private final WebClient aiWebClient;
     private final RecommendationCacheService recommendationCacheService;
-    private final InsuranceProductRepository insuranceProductRepository;
     private final ObjectMapper objectMapper;
 
     /**
@@ -127,18 +125,31 @@ public class RecommendationService {
 
         long ttlSec = (list.getExpiresInSec() == null ? DEFAULT_TTL_SEC : list.getExpiresInSec());
 
-        recommendationCacheService.saveList(list.getResultId(), list, ttlSec);
+        recommendationCacheService.saveListSafely(list.getResultId(), list, ttlSec);
 
         if (list.getItems() != null) {
             for (var item : list.getItems()) {
                 if (item == null || isBlank(item.getItemId())) continue;
 
                 RecommendationResponse detail = RecommendationResponse.fromListItem(item);
-                recommendationCacheService.saveDetail(list.getResultId(), item.getItemId(), detail, ttlSec);
+                recommendationCacheService.saveDetailSafely(list.getResultId(), item.getItemId(), detail, ttlSec);
             }
         }
 
         return list;
+    }
+
+    public RecommendationListResponse getRecommendationList(String resultId) {
+        if (isBlank(resultId)) {
+            throw new CustomException(ExceptionCode.AI_INVALID_REQUEST);
+        }
+
+        RecommendationListResponse cached = recommendationCacheService.getList(resultId);
+        if (cached == null) {
+            throw new CustomException(ExceptionCode.AI_RESULT_NOT_FOUND);
+        }
+
+        return cached;
     }
 
     /**
@@ -154,7 +165,7 @@ public class RecommendationService {
             throw new CustomException(ExceptionCode.AI_INVALID_REQUEST);
         }
 
-        RecommendationResponse cached = recommendationCacheService.getDetail(resultId, itemId);
+        RecommendationResponse cached = recommendationCacheService.findDetailSafely(resultId, itemId);
         if (cached != null) {
             log.info("[FETCH DETAIL] Redis cache HIT. resultId={} itemId={}", resultId, itemId);
             return cached;
@@ -176,7 +187,7 @@ public class RecommendationService {
                 .block();
 
         if (fresh != null) {
-            recommendationCacheService.saveDetail(resultId, itemId, fresh, DEFAULT_TTL_SEC);
+            recommendationCacheService.saveDetailSafely(resultId, itemId, fresh, DEFAULT_TTL_SEC);
         }
 
         return fresh;

--- a/bwlovers/src/main/java/com/capstone/bwlovers/insurance/service/InsuranceService.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/insurance/service/InsuranceService.java
@@ -1,7 +1,7 @@
 package com.capstone.bwlovers.insurance.service;
 
 import com.capstone.bwlovers.ai.recommendation.dto.response.RecommendationResponse;
-import com.capstone.bwlovers.ai.recommendation.service.RecommendationCacheService;
+import com.capstone.bwlovers.ai.recommendation.service.RecommendationService;
 import com.capstone.bwlovers.auth.domain.User;
 import com.capstone.bwlovers.auth.repository.UserRepository;
 import com.capstone.bwlovers.global.exception.CustomException;
@@ -29,7 +29,7 @@ public class InsuranceService {
 
     private final UserRepository userRepository;
     private final InsuranceProductRepository insuranceProductRepository;
-    private final RecommendationCacheService recommendationCacheService;
+    private final RecommendationService recommendationService;
     private final ObjectMapper objectMapper;
 
     @Transactional
@@ -37,7 +37,8 @@ public class InsuranceService {
         User user = findUser(userId);
         validateSaveRequest(request);
 
-        RecommendationResponse detail = recommendationCacheService.getDetail(
+        RecommendationResponse detail = recommendationService.fetchAiResultDetail(
+                userId,
                 request.getResultId(),
                 request.getItemId()
         );

--- a/bwlovers/src/main/java/com/capstone/bwlovers/simulation/repository/SimulationRepository.java
+++ b/bwlovers/src/main/java/com/capstone/bwlovers/simulation/repository/SimulationRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 public interface SimulationRepository extends JpaRepository<Simulation, Long> {
     boolean existsByResultId(String resultId);
     Optional<Simulation> findByResultId(String resultId);
+    @EntityGraph(attributePaths = "contracts")
+    Optional<Simulation> findWithContractsByResultId(String resultId);
     List<Simulation> findByUser_UserIdOrderByCreatedAtAsc(Long userId);
     @EntityGraph(attributePaths = "contracts")
     Optional<Simulation> findByIdAndUser_UserId(Long simulationId, Long userId);

--- a/bwlovers/src/test/java/com/capstone/bwlovers/ai/analysis/service/AnalysisServiceTest.java
+++ b/bwlovers/src/test/java/com/capstone/bwlovers/ai/analysis/service/AnalysisServiceTest.java
@@ -1,0 +1,132 @@
+package com.capstone.bwlovers.ai.analysis.service;
+
+import com.capstone.bwlovers.ai.analysis.dto.response.AnalysisResultResponse;
+import com.capstone.bwlovers.auth.repository.UserRepository;
+import com.capstone.bwlovers.global.exception.CustomException;
+import com.capstone.bwlovers.global.exception.ExceptionCode;
+import com.capstone.bwlovers.insurance.domain.InsuranceProduct;
+import com.capstone.bwlovers.insurance.repository.InsuranceProductRepository;
+import com.capstone.bwlovers.insurance.repository.SpecialContractRepository;
+import com.capstone.bwlovers.simulation.domain.Simulation;
+import com.capstone.bwlovers.simulation.domain.SimulationContract;
+import com.capstone.bwlovers.simulation.repository.SimulationRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnalysisServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private AnalysisCacheService analysisCacheService;
+    @Mock
+    private InsuranceProductRepository insuranceProductRepository;
+    @Mock
+    private SpecialContractRepository specialContractRepository;
+    @Mock
+    private SimulationRepository simulationRepository;
+
+    private AnalysisService analysisService;
+
+    @BeforeEach
+    void setUp() {
+        analysisService = new AnalysisService(
+                userRepository,
+                WebClient.builder().build(),
+                analysisCacheService,
+                insuranceProductRepository,
+                specialContractRepository,
+                simulationRepository,
+                new ObjectMapper()
+        );
+    }
+
+    @Test
+    void getSimulationResult_returnsDatabaseSourceWhenRedisReadFails() {
+        String resultId = "sim-result-1";
+        InsuranceProduct sourceInsurance = sourceInsurance();
+
+        when(analysisCacheService.getResult(resultId))
+                .thenThrow(new CustomException(ExceptionCode.REDIS_CONNECTION_FAILED));
+        when(analysisCacheService.findSourceInsuranceIdSafely(resultId)).thenReturn(99L);
+        when(simulationRepository.findWithContractsByResultId(resultId))
+                .thenReturn(Optional.of(savedSimulation(resultId)));
+        when(insuranceProductRepository.findById(99L))
+                .thenReturn(Optional.of(sourceInsurance));
+
+        AnalysisResultResponse response = analysisService.getSimulationResult(resultId);
+
+        assertEquals(resultId, response.getResultId());
+        assertEquals("ACME", response.getInsuranceCompany());
+        assertEquals("Safe Plan", response.getProductName());
+        assertEquals("보장 내용을 알려줘", response.getQuestion());
+        assertEquals("충분한 보장입니다.", response.getResult());
+        assertEquals(1, response.getSpecialContracts().size());
+        assertEquals("입원 특약", response.getSpecialContracts().get(0).getContractName());
+        assertTrue(response.getLongTerm());
+        assertEquals("1000", response.getSumInsured());
+        assertEquals("10", response.getMonthlyCost());
+        assertEquals("saved memo", response.getMemo());
+        verify(analysisCacheService).saveResultSafely(eq(resultId), any(AnalysisResultResponse.class), eq(2592000L));
+    }
+
+    @Test
+    void getSimulationResult_rethrowsRedisFailureWhenNoFallbackSourceExists() {
+        String resultId = "sim-result-2";
+
+        when(analysisCacheService.getResult(resultId))
+                .thenThrow(new CustomException(ExceptionCode.REDIS_CONNECTION_FAILED));
+        when(simulationRepository.findWithContractsByResultId(resultId))
+                .thenReturn(Optional.empty());
+
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> analysisService.getSimulationResult(resultId)
+        );
+
+        assertEquals(ExceptionCode.REDIS_CONNECTION_FAILED, exception.getExceptionCode());
+    }
+
+    private Simulation savedSimulation(String resultId) {
+        return Simulation.builder()
+                .resultId(resultId)
+                .insuranceCompany("ACME")
+                .productName("Safe Plan")
+                .question("보장 내용을 알려줘")
+                .result("충분한 보장입니다.")
+                .contracts(List.of(
+                        SimulationContract.builder()
+                                .contractName("입원 특약")
+                                .pageNumber(3L)
+                                .build()
+                ))
+                .build();
+    }
+
+    private InsuranceProduct sourceInsurance() {
+        InsuranceProduct insurance = mock(InsuranceProduct.class);
+        when(insurance.isLongTerm()).thenReturn(true);
+        when(insurance.getSumInsured()).thenReturn("1000");
+        when(insurance.getMonthlyCost()).thenReturn("10");
+        when(insurance.getMemo()).thenReturn("saved memo");
+        return insurance;
+    }
+}

--- a/bwlovers/src/test/java/com/capstone/bwlovers/ai/recommendation/service/RecommendationServiceTest.java
+++ b/bwlovers/src/test/java/com/capstone/bwlovers/ai/recommendation/service/RecommendationServiceTest.java
@@ -1,0 +1,98 @@
+package com.capstone.bwlovers.ai.recommendation.service;
+
+import com.capstone.bwlovers.ai.recommendation.dto.response.RecommendationResponse;
+import com.capstone.bwlovers.auth.domain.OAuthProvider;
+import com.capstone.bwlovers.auth.domain.User;
+import com.capstone.bwlovers.auth.repository.UserRepository;
+import com.capstone.bwlovers.health.repository.HealthStatusRepository;
+import com.capstone.bwlovers.pregnancy.repository.PregnancyInfoRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PregnancyInfoRepository pregnancyInfoRepository;
+    @Mock
+    private HealthStatusRepository healthStatusRepository;
+    @Mock
+    private RecommendationCacheService recommendationCacheService;
+
+    private RecommendationService recommendationService;
+
+    @BeforeEach
+    void setUp() {
+        ExchangeFunction exchangeFunction = request -> Mono.just(
+                ClientResponse.create(HttpStatus.OK)
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .body("""
+                                {
+                                  "itemId": "item-1",
+                                  "insurance_company": "ACME",
+                                  "is_long_term": true,
+                                  "product_name": "Safe Plan",
+                                  "insurance_recommendation_reason": "추천 사유",
+                                  "sum_insured": "1000",
+                                  "monthly_cost": "10",
+                                  "special_contracts": [],
+                                  "evidence_sources": []
+                                }
+                                """)
+                        .build()
+        );
+
+        recommendationService = new RecommendationService(
+                userRepository,
+                pregnancyInfoRepository,
+                healthStatusRepository,
+                WebClient.builder().exchangeFunction(exchangeFunction).build(),
+                recommendationCacheService,
+                new ObjectMapper()
+        );
+    }
+
+    @Test
+    void fetchAiResultDetail_readsFromAiWhenCacheMisses() {
+        Long userId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(
+                User.builder()
+                        .userId(userId)
+                        .provider(OAuthProvider.NAVER)
+                        .providerId("provider-1")
+                        .build()
+        ));
+        when(recommendationCacheService.findDetailSafely("result-1", "item-1")).thenReturn(null);
+
+        RecommendationResponse response = recommendationService.fetchAiResultDetail(userId, "result-1", "item-1");
+
+        assertEquals("item-1", response.getItemId());
+        assertEquals("ACME", response.getInsuranceCompany());
+        assertEquals("Safe Plan", response.getProductName());
+        assertEquals("1000", response.getSumInsured());
+        verify(recommendationCacheService)
+                .saveDetailSafely(eq("result-1"), eq("item-1"), any(RecommendationResponse.class), eq(600L));
+    }
+}


### PR DESCRIPTION
## 설명

Redis Cache-Aside 패턴을 보강해, Redis 장애 또는 캐시 조회 실패가 발생하더라도 가능한 경우 원본 데이터를 조회하도록 개선했습니다.

주요 변경은 다음과 같습니다.
- 추천 상세 조회 시 Redis 실패/미스가 발생하면 AI 서버 원본 상세 조회로 폴백
- 보험 선택 저장 시 Redis 캐시에 직접 의존하지 않고 추천 상세 원본 조회 경로를 재사용
- 시뮬레이션 결과 조회 시 Redis 실패 시 DB에 저장된 Simulation 데이터를 이용해 결과 복원
- Redis 저장은 best-effort로 처리하여 캐시 저장 실패가 전체 요청 실패로 이어지지 않도록 변경
- Cache-Aside 설계 문서 및 테스트 코드 추가

<br/>

## 📌 구현 기능

- [x] 추천 상세 조회에 Redis 장애 대응 cache-aside 폴백 적용
- [x] 보험 저장 흐름에서 Redis 직접 의존 제거 및 AI 원본 조회 재사용
- [x] 시뮬레이션 결과 조회 시 DB fallback 및 캐시 재적재 로직 추가
- [x] Redis safe wrapper 로깅 추가
- [x] cache-aside 설계 문서 및 단위 테스트 추가

## 📷 테스트 결과

- `./gradlew test` 통과
- 추가 테스트
  - Redis 조회 실패 시 시뮬레이션 결과를 DB에서 복원하는 케이스 검증
  - 추천 상세 캐시 미스 시 AI 원본 조회 후 재캐시하는 케이스 검증

<br/>

## ⚠️ 어려웠던 점과 해결 과정

- Redis를 단순 캐시로 쓰는 구간과, 사실상 임시 원본 저장소처럼 쓰는 구간이 섞여 있어 일괄적으로 예외를 무시하면 안 됐음
- 해결:
  - 원본 데이터가 따로 있는 흐름에는 safe 접근을 적용
  - Redis가 사실상 유일한 저장소인 흐름은 strict 처리 유지

- 시뮬레이션 결과 조회에서 Redis 장애 시 어디까지 복원할 수 있는지 경계가 애매했음
- 해결:
  - 저장된 `Simulation` + `contracts` 를 DB에서 다시 조회할 수 있도록 Repository 보강
  - 필요 시 `InsuranceProduct` 정보를 이용해 snapshot 필드 보강

- Redis 저장 실패까지 요청 실패로 처리하면 장애 전파 범위가 너무 커졌음
- 해결:
  - 캐시 저장은 best-effort로 바꾸고 warning 로그만 남기도록 수정

<br/>
  
## ⚠️ 참고 사항 및 주의할 점

- `GET /ai/recommend/{resultId}` 추천 리스트 재조회는 아직 Redis 외 원본 저장소가 없어 완전한 폴백이 불가능합니다.
- 아직 DB에 저장되지 않은 시뮬레이션 임시 결과도 Redis 의존성이 남아 있습니다.

<br/>

### 📝 논의사항

- 추천 리스트와 시뮬레이션 임시 결과도 DB 스냅샷으로 저장해 완전한 fallback 구조로 확장할지 논의가 필요합니다.
- Redis fallback 발생 횟수를 메트릭으로 수집할지 검토가 필요합니다.